### PR TITLE
Fix attribute generation in HTMLIFY

### DIFF
--- a/cl-dot.lisp
+++ b/cl-dot.lisp
@@ -343,7 +343,7 @@ FORMAT is Postscript."
            (typecase node
              (cons
               (destructuring-bind (name attributes &rest children) node
-                (format stream "<~A~@[ ~{~{~A=~S~^ ~}~}~]>"
+                (format stream "<~A~@[ ~{~{~A=~S~}~^ ~}~]>"
                         name attributes)
                 (mapc #'textify-node children)
                 (format stream "</~A>" name)))


### PR DESCRIPTION
The previous attribute format string, `~{~{~A=~S~^ ~}~}`, did not write a
space between successive attributes. The correct format string is
`~{~{~A=~S~}~^ ~}`.
