### PR TITLE
added some attributes that are supported by recent versions of graphviz

### DIFF
--- a/attributes.lisp
+++ b/attributes.lisp
@@ -14,7 +14,9 @@
     (:ranksep float)
     (:ordering (:out))
     (:rankdir ("LR" "RL" "BT"))
+    (:dir ("forward" "none"))
     (:pagedir text)
+    (:layout text) ;; neato, twopi, etc.
     (:rank (:same :min :max))
     (:rotate integer)
     (:center integer)
@@ -49,6 +51,7 @@
 (defparameter *edge-attributes*
   '((:minlen integer)
     (:weight integer)
+    (:arrowhead ("normal" "inv" "dot" "invdot" "odot" "invodot" "none" "tee" "empty" "invempty" "diamond" "odiamond" "ediamond" "crow" "box" "obox" "open" "halfopen" "vee" "circle"))
     (:label label-text)
     (:fontsize integer)
     (:fontname text)


### PR DESCRIPTION
Found more attributes listed at http://www.graphviz.org/doc/info/attrs.html than existed in `attributes.lisp`, so added only the ones I wanted to use.

Tested with graphviz version 2.38.0 (20140413.2041).

