### PR TITLE
Use UIOP:RUN-PROGRAM to execute graphviz

### DIFF
--- a/cl-dot.asd
+++ b/cl-dot.asd
@@ -22,4 +22,4 @@
              (:static-file "sb-c-example" :pathname "sb-c-example.lisp")))
    (:module "docs"
             :components
-            ((:html-file "cl-dot.html")))))
+            ((:html-file "cl-dot")))))

--- a/cl-dot.asd
+++ b/cl-dot.asd
@@ -5,6 +5,7 @@
   :description "Generate Dot Output from Arbitrary Lisp Data"
   :author "Juho Snellman <jsnell@iki.fi>"
   :maintainer "Michael Weber <michaelw@foldr.org>"
+  :depends-on (:uiop)
   :serial t
   :components
   ((:file "package")

--- a/cl-dot.lisp
+++ b/cl-dot.lisp
@@ -140,41 +140,15 @@ argument.  The default is a directed graph.  The default
 FORMAT is Postscript."
   (when (null format) (setf format :ps))
 
-  (let ((dot-path (if directed *dot-path* *neato-path*)))
-    #+sbcl
-    (let ((dot-string (with-output-to-string (stream)
-                        (print-graph graph
-                                     :stream stream
-                                     :directed directed))))
-      (sb-ext:run-program dot-path
-                          (list (format nil "-T~(~a~)" format) "-o" outfile)
-                          :input (make-string-input-stream dot-string)
-                          :output *standard-output*))
-    #+allegro
-    (excl.osi:with-command-io
-        ((format nil "~A -T~(~a~) -o ~A" dot-path format outfile))
-      (:input (dot-stream)
-              (print-graph graph
-                           :stream dot-stream
-                           :directed directed)))
-    #+lispworks
-    (with-open-stream
-        (dot-stream (sys:open-pipe (format nil "~A -T~(~a~) -o ~A"
-                                           dot-path format outfile)
-                                   :direction :input))
-      (print-graph graph
-                   :stream dot-stream
-                   :directed directed)
-      (force-output dot-stream))
-    #+clisp
-    (with-open-stream (out (ext:make-pipe-output-stream
-                            (format nil "~A -T~(~a~) -o ~A"
-                                    dot-path format outfile)))
-      (print-graph graph
-                   :stream out
-                   :directed directed))
-    #-(or sbcl lispworks allegro clisp)
-    (error "Don't know how to execute a program on this platform")))
+  (let ((dot-path (if directed *dot-path* *neato-path*))
+        (format (format nil "-T~(~a~)" format))
+        (dot-string (with-output-to-string (stream)
+                      (print-graph graph
+                                   :stream stream
+                                   :directed directed))))
+    (uiop:run-program (list dot-path format "-o" outfile)
+                      :input (make-string-input-stream dot-string)
+                      :output *standard-output*)))
 
 ;;; Internal
 (defun construct-graph (graph objects)

--- a/docs/manual.texi
+++ b/docs/manual.texi
@@ -120,14 +120,8 @@ with the software or the use or other dealings in the software.}
 
 CL-DOT is a small package for easily generating Dot (a program in the
 @url{http://www.graphviz.org/,GraphViz} suite) output from arbitrary
-Lisp data.  It works with the following Common Lisp implementations:
-
-@itemize @bullet
-@item @url{http://www.franz.com/products/allegrocl/,Allegro CL@registeredsymbol{}}
-@item @url{http://clisp.cons.org/,@acronym{GNU} CLISP}
-@item @url{http://www.lispworks.com/,LispWorks}
-@item @url{http://www.sbcl.org/,@acronym{SBCL}}
-@end itemize
+Lisp data.  It should work with any Common Lisp implementation supported
+by @url{https://www.common-lisp.net/project/asdf/,@acronym{UIOP}}.
 
 Original author is @url{http://jsnell.iki.fi/,Juho Snellman}, current
 maintainer is @url{http://www.foldr.org/~michaelw/,Michael Weber}.  The
@@ -215,11 +209,12 @@ The source code is available via @url{http://github.com/,GitHub}:
 
 @section External Dependencies
 
-CL-DOT has no dependencies on other
-@url{http://weitz.de/packages.html,systems}, but it requires the
-@url{http://www.graphviz.org/,GraphViz} suite to be installed for
-rendering, and @url{http://www.gnu.org/software/texinfo/,GNU Texinfo}
-for preparing this documentation.
+The only @url{http://weitz.de/packages.html,systems} CL-DOT depends on
+is @url{https://www.common-lisp.net/project/asdf/,@acronym{UIOP}}. In
+addition, it requires the @url{http://www.graphviz.org/,GraphViz} suite
+to be installed for rendering, and
+@url{http://www.gnu.org/software/texinfo/,GNU Texinfo} for preparing
+this documentation.
 
 @c -----------------------------------------------------------------
 @node Usage


### PR DESCRIPTION
Please consider this patch to use ``uiop:run-program`` to execute graphviz instead of several implementation-specific special cases.

This should let cl-dot work on more implementations and at the same time make the code simpler. In times of Quicklisp, the UIOP dependency should not cause any problems. In many implementations, it is even available out-of-the-box since it is bundled with ASDF.