### PR TITLE
Added several new node shapes

### DIFF
--- a/attributes.lisp
+++ b/attributes.lisp
@@ -36,9 +36,21 @@
     (:width integer)
     (:fixed-size boolean)
     (:label label-text)
-    (:shape (:record :plaintext :ellipse :circle :egg :triangle :box
-             :diamond :trapezium :parallelogram :house :hexagon :octagon
-             :doubleoctagon))
+    (:shape (:box :polygon :ellipse :oval
+             :circle :point :egg :triangle
+             :plaintext :plain :diamond :trapezium
+             :parallelogram :house :pentagon :hexagon
+             :septagon :octagon :doublecircle :doubleoctagon
+             :tripleoctagon :invtriangle :invtrapezium :infhouse
+             :Mdiamond :Msquare :Mcircle :rect
+             :rectangle :square :star :none
+             :underline :cylinder :note :tab
+             :folder :box3d :component :promoter
+             :cds :terminator :utr :primersite
+             :restrictionsite :fivepoverhang :threepoverhang :noverhang
+             :assembly :signature :insulator :ribosite
+             :rnastab :proteasesite :proteinstab :rpromoter
+             :rarrow :larrow :lpromoter :record))
     (:fontsize integer)
     (:fontname text)
     (:color text)

--- a/docs/manual.texi
+++ b/docs/manual.texi
@@ -620,8 +620,21 @@ are horizontally centered in Dot output.  However, if the value of
 @var{shape} can be one of the following keywords:
 
 @lisp
-:record :plaintext :ellipse :circle :egg :triangle :box
-:diamond :trapezium :parallelogram :house :hexagon :octagon
+:box :polygon :ellipse :oval
+:circle :point :egg :triangle
+:plaintext :plain :diamond :trapezium
+:parallelogram :house :pentagon :hexagon
+:septagon :octagon :doublecircle :doubleoctagon
+:tripleoctagon :invtriangle :invtrapezium :infhouse
+:Mdiamond :Msquare :Mcircle :rect
+:rectangle :square :star :none
+:underline :cylinder :note :tab
+:folder :box3d :component :promoter
+:cds :terminator :utr :primersite
+:restrictionsite :fivepoverhang :threepoverhang :noverhang
+:assembly :signature :insulator :ribosite
+:rnastab :proteasesite :proteinstab :rpromoter
+:rarrow :larrow :lpromoter :record
 @end lisp
 
 @item :style (:filled :solid :dashed :dotted :bold :invis)


### PR DESCRIPTION
I copied the node shapes from the [Graphviz manual](https://web.archive.org/web/20160402052242/http://www.graphviz.org/content/node-shapes) along with the pre-existing `:record`.

Here's a quick test I did to make sure they all work properly:
```lisp
(in-package :cl-dot)

(defmethod graph-object-node ((graph (eql :nodetest)) l)
  (make-instance 'node
                 :attributes (append (and (car l) `(:shape ,(car l)))
                                     `(:label ,(write-to-string (car l))))))

(defmethod graph-object-points-to ((graph (eql :nodetest)) l)
  (list (cdr l)))

(dot-graph (generate-graph-from-roots
            :nodetest (cdr (assoc :shape *node-attributes*)))
           "/tmp/test.ps" :format :ps)
````