### PR TITLE
Allow node `width` and `height` attributes to accept floats

### DIFF
--- a/attributes.lisp
+++ b/attributes.lisp
@@ -32,8 +32,8 @@
     (:stylesheet text)))
 
 (defparameter *node-attributes*
-  '((:height integer)
-    (:width integer)
+  '((:height float)
+    (:width float)
     (:fixed-size boolean)
     (:label label-text)
     (:shape (:box :polygon :ellipse :oval


### PR DESCRIPTION
The node width/height attributes in graphviz take doubles, not integers, so cl-dot should allow floats for these attributes.  See the `type` column at http://www.graphviz.org/doc/info/attrs.html