### PR TITLE
Add support for finding program on path on Windows

### DIFF
--- a/config-graphviz.lisp
+++ b/config-graphviz.lisp
@@ -30,8 +30,9 @@ path, or search of likely installation locations."
 
 
 (defun check-in-path (name)
-  (unless (uiop:os-windows-p)
-    (multiple-value-bind (outstring errstring exit-code)
-        (uiop:run-program (format nil "which ~a" name) :force-shell t :output '(:string :stripped t) :ignore-error-status t)
-      (declare (ignore errstring))
-      (when (zerop exit-code) outstring))))
+  (multiple-value-bind (outstring errstring exit-code)
+      (uiop:run-program (list  #+(or win32 mswindows)"where"
+                               #-(or win32 mswindows)"which"
+                               name) :force-shell t :output '(:string :stripped t) :ignore-error-status t)
+    (declare (ignore errstring))
+    (when (zerop exit-code) (uiop:parse-native-namestring outstring))))


### PR DESCRIPTION
This fixes #25 

Makes use of the `where` command on Windows to look for programs on PATH
Note also changing `(format nil "where ~a" name)` to `(list "where" name)`. I believe this makes the code cleaner, but I wasn't sure if I should have changed instead to `(list "where" (format nil "~a" name))` to "coerce" `name` into a string.

Feedback appreciated!