### PR TITLE
Export more symbols

### DIFF
--- a/cl-dot.asd
+++ b/cl-dot.asd
@@ -1,7 +1,7 @@
 ;; -*- Syntax: Ansi-Common-Lisp; Mode: lisp; -*-
 
 (asdf:defsystem :cl-dot
-  :version "0.8.0"
+  :version "0.9.0"
   :description "Generate Dot Output from Arbitrary Lisp Data"
   :author "Juho Snellman <jsnell@iki.fi>"
   :maintainer "Michael Weber <michaelw@foldr.org>"

--- a/package.lisp
+++ b/package.lisp
@@ -9,7 +9,10 @@
            #:graph-object-points-to #:graph-object-pointed-to-by
            #:graph-object-edges
            #:generate-graph-from-roots
-           #:print-graph #:dot-graph)
+           #:print-graph #:dot-graph
+           #:edge #:graph
+           #:id-of #:nodes-of #:edges-of #:attributes-of
+           #:source-of #:target-of)
   ;; deprecated
   (:export #:object-knows-of #:object-node
            #:object-points-to #:object-pointed-to-by


### PR DESCRIPTION
I'm working on an improved [graph formatter extension for McCLIM](https://github.com/McCLIM/McCLIM/pull/1197). This extension takes the graph built up using CLIM's API, generates a `cl-dot::graph` instance from it, then calls some user specified function to perform the layout. This function must return a `cl-dot::graph` instance with all the relevant layout attributes (like `pos` and `lp`) set.

The default layout function just calls dot with `-Tjson0`, parses the JSON output, and creates a `cl-dot::graph` instance. This is why I'd like to export `edge` and `graph`. I can probably make do without exporting these symbols (and build the graph using `generate-graph-from-roots`), but it would be annoying.

Then, to generate the output records for McCLIM, it needs to walk all the nodes and edges of the returned graph, looking at their attributes, id, source, and target. Hence exporting `id-of`, `nodes-of`, `edges-of`, `attributes-of`, `source-of`, and `target-of`.

If you're interested, I can also open a PR that includes the json0 -> `graph` parser.