### PR TITLE
Remove concept index from docs

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -56,7 +56,7 @@ version.texi.tmp:
 
 %.pdf: %.texi
 	$(PDFTEX) $<
-	$(TEXINDEX) $*.{cp,fn,vr,tp}
+	$(TEXINDEX) $*.{fn,vr,tp}
 	$(PDFTEX) $<
 
 .PHONY: all clean real-clean install install-data install-info


### PR DESCRIPTION
For whatever reason, including the concept index in the makefile for docs causes the docs build to fail.

I believe that this is probably because there are no entries for this index, since the error is:

```
Output written on manual.pdf (21 pages, 310703 bytes).
Transcript written on manual.log.
texindex manual.{cp,fn,vr,tp}
/usr/bin/awk: can't open file manual.cp
 source line number 372
make: *** [manual.pdf] Error 2
```