### PR TITLE
Fix for LispWorks where `RUN-SHELL-COMMAND' must not have pathnames.

### DIFF
--- a/config-graphviz.lisp
+++ b/config-graphviz.lisp
@@ -35,4 +35,5 @@ path, or search of likely installation locations."
                                #-(or win32 mswindows)"which"
                                name) :force-shell t :output '(:string :stripped t) :ignore-error-status t)
     (declare (ignore errstring))
-    (when (zerop exit-code) (uiop:parse-native-namestring outstring))))
+    (when (zerop exit-code) (namestring
+                             (uiop:parse-native-namestring outstring)))))


### PR DESCRIPTION
Seems `CHECK-IN-PATH' uses `uiop:parse-native-namestring' which return pathname.

The solution now only uses strings.

Here is a stacktrace when run from LispWorks:

```
Backtrace:
 0: (CONDITIONS::CONDITIONS-ERROR :INVISIBLEP T "Each element of COMMAND must be of type STRING : ~A" (("/usr/bin/env" #P"/opt/homebrew/bin/dot" "-Tpng" "-o" "hcp.png")))
      Locals:
        DATUM = "Each element of COMMAND must be of type STRING : ~A"
        ARGUMENTS = (("/usr/bin/env" #P"/opt/homebrew/bin/dot" "-Tpng" "-o" "hcp.png"))
 1: (ERROR "Each element of COMMAND must be of type STRING : ~A" ("/usr/bin/env" #P"/opt/homebrew/bin/dot" "-Tpng" "-o" "hcp.png"))
 2: (SYSTEM::PROCESS-COMMAND-OPTIONS ("/usr/bin/env" #P"/opt/homebrew/bin/dot" "-Tpng" "-o" "hcp.png") "/bin/zsh")
 3: (SYSTEM:RUN-SHELL-COMMAND ("/usr/bin/env" #P"/opt/homebrew/bin/dot" "-Tpng" "-o" "hcp.png") :INPUT #P"/var/folders/2z/831jl36d01317d4pz3g2_j100000gn/T/tmpZ9G2IR9X.tmp" :OUTPUT :STREAM ...)
 4: ((HARLEQUIN-COMMON-LISP:SUBFUNCTION 1 UIOP/LAUNCH-PROGRAM:LAUNCH-PROGRAM))
 5: (UIOP/LAUNCH-PROGRAM:LAUNCH-PROGRAM (#P"/opt/homebrew/bin/dot" "-Tpng" "-o" "hcp.png") "<KEYS>")
 6: ((HARLEQUIN-COMMON-LISP:SUBFUNCTION 1 (HARLEQUIN-COMMON-LISP:SUBFUNCTION 1 (HARLEQUIN-COMMON-LISP:SUBFUNCTION 1 UIOP/RUN-PROGRAM::%USE-LAUNCH-PROGRAM))) ..)
 7: (UIOP/UTILITY:CALL-FUNCTION #<Closure (FLET #:BEFORE45453) subfunction of (HARLEQUIN-COMMON-LISP:SUBFUNCTION ..))
 8: (UIOP/STREAM:CALL-WITH-TEMPORARY-FILE #<Closure (FLET #:BEFORE45453) subfunction of (HARLEQUIN-COMMON-LISP:SUBFUNCTION ..))
 9: ((HARLEQUIN-COMMON-LISP:SUBFUNCTION (LABELS UIOP/RUN-PROGRAM::HARD-CASE) UIOP/RUN-PROGRAM::%CALL-WITH-PROGRAM-IO))
10: (UIOP/RUN-PROGRAM::%CALL-WITH-PROGRAM-IO UIOP/RUN-PROGRAM:VOMIT-OUTPUT-STREAM ..)
11: (UIOP/RUN-PROGRAM::%CALL-WITH-PROGRAM-IO UIOP/RUN-PROGRAM:SLURP-INPUT-STREAM ..)
12: ((HARLEQUIN-COMMON-LISP:SUBFUNCTION (LABELS UIOP/RUN-PROGRAM::HARD-CASE) UIOP/RUN-PROGRAM::%CALL-WITH-PROGRAM-IO))
13: (UIOP/RUN-PROGRAM::%CALL-WITH-PROGRAM-IO UIOP/RUN-PROGRAM:SLURP-INPUT-STREAM ..)
14: (UIOP/RUN-PROGRAM::%USE-LAUNCH-PROGRAM (#P"/opt/homebrew/bin/dot" "-Tpng" "-o" "hcp.png") "<KEYS>")
      Locals:
        COMMAND = (#P"/opt/homebrew/bin/dot" "-Tpng" "-o" "hcp.png")
        DBG::|rest-| = (:INPUT #<SYSTEM::STRING-INPUT-STREAM 8010081F3B> :OUTPUT #<SLYNK-GRAY::SLY-OUTPUT-STREAM 820001881B>)
        INPUT = #<SYSTEM::STRING-INPUT-STREAM 8010081F3B>
        OUTPUT = #<SLYNK-GRAY::SLY-OUTPUT-STREAM 820001881B>
        ERROR-OUTPUT = NIL
        IGNORE-ERROR-STATUS = NIL
        ACTIVE-INPUT-P = T
        ACTIVE-OUTPUT-P = T
        ACTIVE-ERROR-OUTPUT-P = NIL
        ACTIVITY = :OUTPUT
        OUTPUT-RESULT = NIL
        ERROR-OUTPUT-RESULT = NIL
        EXIT-CODE = NIL
        PROCESS-INFO = NIL
15: (SYSTEM::%INVOKE :INVISIBLEP T)
16: (SYSTEM::%EVAL (CL-DOT:DOT-GRAPH * "hcp.png" :FORMAT :PNG))
17: (EVAL (CL-DOT:DOT-GRAPH * "hcp.png" :FORMAT :PNG))
```